### PR TITLE
[4/5][main <- sdk] cleanup debug and error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@alchemy/aa-alchemy": "^0.1.0-alpha.21",
     "@alchemy/aa-core": "^0.1.0-alpha.20",
-    "@bugsnag/js": "^7.21.0",
+    "@bugsnag/js": "^7.22.3",
     "@bugsnag/plugin-react": "^7.19.0",
     "@emotion/react": "^11.11.1",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/src/helpers/bugsnag.ts
+++ b/src/helpers/bugsnag.ts
@@ -4,14 +4,13 @@ import BugsnagPluginReact, {
 } from "@bugsnag/plugin-react";
 import React from "react";
 import { track } from "@vercel/analytics/server";
+import { IS_DEBUG } from "./constants";
 
 export let ErrorBoundary: BugsnagErrorBoundary;
 
 export function start() {
   if (ErrorBoundary) {
-    (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
-      ? console.log("Bugsnag already started")
-      : null;
+    IS_DEBUG ? console.log("Bugsnag already started") : null;
     return;
   }
   Bugsnag.start({
@@ -27,49 +26,41 @@ export function start() {
 }
 
 export function logInfo(where: string, message: string) {
-  (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
+  IS_DEBUG
     ? console.log(`[logInfo][where: ${where}] ${message}`)
     : track(`[logInfo][where: ${where}] ${message}`);
   Bugsnag.addMetadata("log", where, message);
 }
 
 export function logWarning(message: string) {
-  (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
-    ? console.warn(`[logWarning] ${message}`)
-    : null;
+  IS_DEBUG ? console.warn(`[logWarning] ${message}`) : null;
   Bugsnag.notify(new Error(message));
 }
 
 export function logErrorMsg(message: string) {
-  (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
-    ? console.error(`[logErrorMsg] ${message}`)
-    : null;
+  IS_DEBUG ? console.error(`[logErrorMsg] ${message}`) : null;
   Bugsnag.notify(new Error(message));
 }
 
 export function logMetadata(about: string, key: string, value: string) {
-  (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
+  IS_DEBUG
     ? console.log(`[logMetadata][about: ${about}] ${key}: ${value}`)
     : null;
   Bugsnag.addMetadata(about, key, value);
 }
 
 export function logError(error: Error) {
-  process.env.NEXT_PUBLIC_DEBUG
-    ? console.error(`[logError] ${JSON.stringify(error)}`)
-    : null;
+  IS_DEBUG ? console.error(`[logError] ${JSON.stringify(error)}`) : null;
   Bugsnag.notify(error);
 }
 
 export function startSession() {
-  (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
-    ? console.log(`[startSession] debug`)
-    : null;
+  IS_DEBUG ? console.log(`[startSession] debug`) : null;
   Bugsnag.startSession();
 }
 
 export function logUser(id: string, username: string) {
-  (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
+  IS_DEBUG
     ? console.log(`[logUser] ${id}: ${username}`)
     : track(`[logUser] ${id}: ${username}`);
   Bugsnag.setUser(id, username);

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,1 +1,2 @@
 export const STATE_KEY = "igloo-state";
+export const IS_DEBUG = process.env.NEXT_PUBLIC_DEBUG === "true";

--- a/src/helpers/promise.ts
+++ b/src/helpers/promise.ts
@@ -10,13 +10,15 @@ export async function retry<T extends (...arg0: any[]) => any>(
   try {
     const result = await fn(...args);
     return result;
-  } catch (e) {
+  } catch (error) {
     logInfo("retry", `Retry ${currRetry} failed.`);
     if (currRetry > maxTry) {
       logError(
-        new Error(`[retry] All retry attempts exhausted. ${JSON.stringify(e)}`)
+        new Error(
+          `[retry] All retry attempts exhausted. ${JSON.stringify(error)}`
+        )
       );
-      throw e;
+      throw error;
     }
     return retry(fn, args, maxTry, currRetry + 1);
   }

--- a/src/pages/Views/AuthView.tsx
+++ b/src/pages/Views/AuthView.tsx
@@ -34,9 +34,9 @@ export default function AuthView() {
       await snowball.register(username);
 
       dispatch(setView(AuthViews.MINTED));
-    } catch (e) {
+    } catch (error) {
       track("Signup Failure");
-      logErrorMsg(`${e}`);
+      logErrorMsg(`${error}`);
       dispatch(setErrorMsg("Error creating passkey"));
     }
   }
@@ -52,9 +52,9 @@ export default function AuthView() {
       const address = await snowball.getAddress();
 
       dispatch(authenticated(address));
-    } catch (e) {
-      track(`Auth Failed ${JSON.stringify(e)}`);
-      logErrorMsg(`${e}`);
+    } catch (error) {
+      track(`Auth Failed ${JSON.stringify(error)}`);
+      logErrorMsg(`${error}`);
       dispatch(setErrorMsg("Error authenticating passkey"));
     }
   }

--- a/src/pages/Views/WalletView.tsx
+++ b/src/pages/Views/WalletView.tsx
@@ -80,8 +80,8 @@ const WalletView = ({}: WalletViewProps) => {
       );
 
       return result;
-    } catch (e) {
-      logErrorMsg(`Error sending user operation ${e}`);
+    } catch (error) {
+      logErrorMsg(`Error sending user operation ${error}`);
       dispatch(setErrorMsg("Error sending user operation"));
     }
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { Analytics } from "@vercel/analytics/react";
 import Box from "@/components/Box";
 import "../styles/globals.css";
 import { ErrorBoundary, start } from "@/helpers/bugsnag";
+import { IS_DEBUG } from "@/helpers/constants";
 
 start();
 
@@ -33,12 +34,8 @@ function MyApp({ Component, pageProps }: AppProps) {
         <Box>
           <Component {...pageProps} />
           <Analytics
-            mode={
-              (process.env.NEXT_PUBLIC_DEBUG as string) === "true"
-                ? "development"
-                : "production"
-            }
-            debug={(process.env.NEXT_PUBLIC_DEBUG as string) === "true"}
+            mode={IS_DEBUG ? "development" : "production"}
+            debug={IS_DEBUG}
           />
         </Box>
       </Provider>

--- a/src/pages/api/iglooNFTWebhook.ts
+++ b/src/pages/api/iglooNFTWebhook.ts
@@ -75,7 +75,7 @@ export async function updateWebhookAddressesForChain(
       `sent webhook update for addresses: ${newAddresses} and removed: ${removeAddress}`
     );
     logInfo("updateWebhookAddressesForChain", json);
-  } catch (err) {
-    logErrorMsg(`${err}`);
+  } catch (error) {
+    logErrorMsg(`${error}`);
   }
 }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the version of the `@bugsnag/js` package to `^7.22.3` in the `package.json` file. It also makes changes to the `bugsnag.ts` file, replacing the usage of `process.env.NEXT_PUBLIC_DEBUG` with the constant `IS_DEBUG` defined in the `constants.ts` file. Additionally, there are changes in the `promise.ts`, `AuthView.tsx`, `WalletView.tsx`, and `_app.tsx` files to handle error logging and messaging. Finally, there is an update in the `iglooNFTWebhook.ts` file to handle error logging.
> 
> ## What changed
> - Updated the version of `@bugsnag/js` package to `^7.22.3` in `package.json`
> - Replaced the usage of `process.env.NEXT_PUBLIC_DEBUG` with `IS_DEBUG` constant in `bugsnag.ts`
> - Updated error logging and messaging in `promise.ts`, `AuthView.tsx`, `WalletView.tsx`, and `_app.tsx`
> - Updated error logging in `iglooNFTWebhook.ts`
> 
> ## How to test
> 1. Update the `@bugsnag/js` package to `^7.22.3` in the `package.json` file
> 2. Replace the usage of `process.env.NEXT_PUBLIC_DEBUG` with `IS_DEBUG` constant in the `bugsnag.ts` file
> 3. Test the error logging and messaging in the `promise.ts`, `AuthView.tsx`, `WalletView.tsx`, and `_app.tsx` files
> 4. Test the error logging in the `iglooNFTWebhook.ts` file
> 
> ## Why make this change
> - Update the `@bugsnag/js` package to the latest version for bug fixes and improvements
> - Replace the usage of `process.env.NEXT_PUBLIC_DEBUG` with a constant for better code readability and maintainability
> - Improve error logging and messaging for better debugging and user experience
</details>