### PR TITLE
[5/5][main <- sdk] cleanup imports

### DIFF
--- a/src/components/ChainMenuItem.tsx
+++ b/src/components/ChainMenuItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Chain, getChainIcon } from "../helpers/chains";
+import { Chain, getChainIcon } from "@/helpers/chains";
 import Image from "next/image";
 
 interface ChainMenuItemProps {

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Chain } from "../helpers/chains";
+import { Chain } from "@/helpers/chains";
 import ChainMenuItem from "./ChainMenuItem";
 
 interface DropDownMenuProps {

--- a/src/pages/Views/AuthView.tsx
+++ b/src/pages/Views/AuthView.tsx
@@ -8,11 +8,11 @@ import {
   AuthViews,
   disconnect,
   authenticated,
-} from "../../store/credentialsSlice";
-import { snowball } from "../../helpers/webauthn";
+} from "@/store/credentialsSlice";
+import { snowball } from "@/helpers/webauthn";
 import InitialView from "./InitialView";
 import SignUpView from "./SignUpView";
-import Header from "../../components/Header";
+import Header from "@/components/Header";
 import StickyButtonGroup from "@/components/StickyButtonGroup";
 import LoadingAnimation from "@/components/LoadingAnimation";
 import { RootState } from "@/store/store";

--- a/src/pages/Views/MintedIglooNFTView.tsx
+++ b/src/pages/Views/MintedIglooNFTView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Header from "../../components/Header";
+import Header from "@/components/Header";
 import { AuthViews } from "@/store/credentialsSlice";
 import StickyButtonGroup from "@/components/StickyButtonGroup";
 import { Chain } from "@/helpers/chains";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react";
 import { Provider } from "react-redux";
-import { store } from "../store/store";
+import { store } from "@/store/store";
 import type { AppProps } from "next/app";
 import { Analytics } from "@vercel/analytics/react";
 import Box from "@/components/Box";
-import "../styles/globals.css";
+import "@/styles/globals.css";
 import { ErrorBoundary, start } from "@/helpers/bugsnag";
 import { IS_DEBUG } from "@/helpers/constants";
 

--- a/src/store/credentialsSlice.ts
+++ b/src/store/credentialsSlice.ts
@@ -1,6 +1,6 @@
 import { AuthMethod, SessionSigsMap } from "@lit-protocol/types";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { Chain, CHAINS } from "../helpers/chains";
+import { Chain, CHAINS } from "@/helpers/chains";
 import { Address } from "viem";
 
 export const AuthViews = {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the import paths in the project to use absolute paths instead of relative paths. This makes the code more readable and maintainable.
> 
> ## What changed
> The import paths in several files were changed from relative paths to absolute paths. This includes the import paths in `ChainMenuItem.tsx`, `DropDownMenu.tsx`, `AuthView.tsx`, `MintedIglooNFTView.tsx`, `_app.tsx`, and `credentialsSlice.ts`.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run the application and ensure that it works as expected without any import errors.
> 3. Check the changed files to ensure that the import paths have been correctly updated.
> 
> ## Why make this change
> Relative paths can become confusing and hard to manage in large projects. By using absolute paths, we can make the code more readable and easier to maintain. It also makes it easier to move files around in the project structure without having to update the import paths.
</details>