### PR TITLE
remove redundant chain type

### DIFF
--- a/src/components/ChainMenuItem.tsx
+++ b/src/components/ChainMenuItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Chain, getChainIcon } from "@/helpers/chains";
+import { getChainIcon } from "@/helpers/chains";
 import Image from "next/image";
+import { Chain } from "@snowballtools/snowball-ts-sdk";
 
 interface ChainMenuItemProps {
   chain: Chain;

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Chain } from "@/helpers/chains";
 import ChainMenuItem from "./ChainMenuItem";
+import { Chain } from "@snowballtools/snowball-ts-sdk";
 
 interface DropDownMenuProps {
   currentChain: Chain;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import DropdownMenu from "./DropDownMenu";
 import Image from "next/image";
-import { Chain } from "@/helpers/chains";
+import { Chain } from "@snowballtools/snowball-ts-sdk";
 
 interface NavBarProps {
   currentChain: Chain;

--- a/src/components/TestView.tsx
+++ b/src/components/TestView.tsx
@@ -3,9 +3,9 @@ import WalletView from "@/pages/Views/WalletView";
 import Box from "@/components/Box";
 import SignUpView from "@/pages/Views/SignUpView";
 import MintedIglooNFT from "@/pages/Views/MintedIglooNFTView";
-import { CHAINS } from "@/helpers/chains";
 import InitialView from "@/pages/Views/InitialView";
 import LoadingAnimation from "./LoadingAnimation";
+import { CHAINS } from "@snowballtools/snowball-ts-sdk";
 
 interface TestViewProps {}
 

--- a/src/helpers/chains.ts
+++ b/src/helpers/chains.ts
@@ -1,179 +1,20 @@
 import { Address } from "viem";
 import { mainnet, sepolia, goerli, Chain as ViemChain } from "viem/chains";
 import { Network } from "alchemy-sdk";
-
-export interface Chain {
-  chainId: number;
-  name: string;
-  symbol: string;
-  decimals: number;
-  type: string;
-  enabled: boolean;
-  rpcUrls: string[];
-  blockExplorerUrls: string[];
-  vmType: string;
-  testNetwork: boolean;
-  factoryAddress: Address;
-  entryPointAddress: Address;
-  iglooNFTAddress: Address;
-}
-
-export const CHAINS = {
-  ethereum: {
-    chainId: 1,
-    name: "Ethereum",
-    symbol: "ETH",
-    decimals: 18,
-    type: "ERC1155",
-    enabled: false,
-    rpcUrls: ["https://eth-mainnet.alchemyapi.io/v2/"],
-    blockExplorerUrls: ["https://etherscan.io"],
-    vmType: "EVM",
-    testNetwork: false,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789" as Address,
-    iglooNFTAddress: "0x799e75059126E6DA27A164d1315b1963Fb82c44F" as Address,
-  },
-  goerli: {
-    chainId: 5,
-    name: "Goerli",
-    symbol: "ETH",
-    decimals: 18,
-    rpcUrls: ["https://eth-goerli.g.alchemy.com/v2/"],
-    blockExplorerUrls: ["https://goerli.etherscan.io"],
-    type: "ERC1155",
-    enabled: false,
-    vmType: "EVM",
-    testNetwork: true,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789" as Address,
-    iglooNFTAddress: "0x799e75059126E6DA27A164d1315b1963Fb82c44F" as Address,
-  },
-  sepolia: {
-    chainId: 11155111,
-    name: "Sepolia",
-    symbol: "ETH",
-    decimals: 18,
-    rpcUrls: ["https://eth-sepolia.g.alchemy.com/v2/"],
-    blockExplorerUrls: ["https://sepolia.etherscan.io"],
-    type: "ERC1155",
-    enabled: true,
-    vmType: "EVM",
-    testNetwork: true,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  mantle: {
-    chainId: 5000,
-    name: "Mantle",
-    symbol: "MNT",
-    decimals: 18,
-    type: "ERC1155",
-    enabled: false,
-    rpcUrls: ["https://explorer.mantle.xyz/api/eth-rpc"],
-    blockExplorerUrls: ["https://explorer.mantle.xyz/"],
-    vmType: "EVM",
-    testNetwork: false,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  mantle_testnet: {
-    chainId: 5001,
-    name: "Ringwood",
-    symbol: "MNT",
-    decimals: 18,
-    type: "ERC1155",
-    enabled: false,
-    rpcUrls: [
-      "https://rpc.ankr.com/mantle_testnet/1a2aec0bfde1e926c21f0f91e0c90d35ec85093c8bbb9435137067b0f6e36056",
-    ],
-    blockExplorerUrls: ["https://explorer.testnet.mantle.xyz/"],
-    vmType: "EVM",
-    testNetwork: true,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  polygon: {
-    chainId: 137,
-    name: "Polygon",
-    symbol: "MATIC",
-    decimals: 18,
-    rpcUrls: ["https://polygon-rpc.com"],
-    blockExplorerUrls: ["https://explorer.matic.network"],
-    type: "ERC1155",
-    enabled: false,
-    vmType: "EVM",
-    testNetwork: false,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  mumbai: {
-    chainId: 80001,
-    name: "Mumbai",
-    symbol: "MATIC",
-    decimals: 18,
-    rpcUrls: ["https://rpc-mumbai.maticvigil.com/v1/"],
-    blockExplorerUrls: ["https://mumbai.polygonscan.com"],
-    type: "ERC1155",
-    enabled: false,
-    vmType: "EVM",
-    testNetwork: true,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  arbitrum: {
-    chainId: 42161,
-    name: "Arbitrum",
-    symbol: "AETH",
-    decimals: 18,
-    type: "ERC1155",
-    enabled: false,
-    rpcUrls: ["https://arb1.arbitrum.io/rpc"],
-    blockExplorerUrls: ["https://arbiscan.io/"],
-    vmType: "EVM",
-    testNetwork: false,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  optimism: {
-    chainId: 10,
-    name: "Optimism",
-    symbol: "ETH",
-    decimals: 18,
-    rpcUrls: ["https://mainnet.optimism.io"],
-    blockExplorerUrls: ["https://optimistic.etherscan.io"],
-    type: "ERC1155",
-    enabled: false,
-    vmType: "EVM",
-    testNetwork: false,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-  celo: {
-    chainId: 42220,
-    name: "Celo",
-    symbol: "CELO",
-    decimals: 18,
-    rpcUrls: ["https://forno.celo.org"],
-    blockExplorerUrls: ["https://explorer.celo.org"],
-    type: "ERC1155",
-    enabled: false,
-    vmType: "EVM",
-    testNetwork: false,
-    factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    entryPointAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
-    iglooNFTAddress: "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address,
-  },
-} as { [key: string]: Chain };
+import { CHAINS, Chain } from "@snowballtools/snowball-ts-sdk";
 
 export const DEFAULT_CHAIN = CHAINS.sepolia;
+
+export function getIglooNFTAddress(chain: Chain): Address {
+  switch (chain) {
+    case CHAINS.goerli:
+      return "0x799e75059126E6DA27A164d1315b1963Fb82c44F" as Address;
+    case CHAINS.sepolia:
+      return "0x98AdA10fC1EAf5d21DB0f91d09fAa6165e427106" as Address;
+    default:
+      throw new Error("Unsupported chain");
+  }
+}
 
 export function alchemyAPIKey(chain: Chain): string {
   switch (chain) {

--- a/src/pages/Views/MintedIglooNFTView.tsx
+++ b/src/pages/Views/MintedIglooNFTView.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import Header from "@/components/Header";
 import { AuthViews } from "@/store/credentialsSlice";
 import StickyButtonGroup from "@/components/StickyButtonGroup";
-import { Chain } from "@/helpers/chains";
 import Image from "next/image";
+import { Chain } from "@snowballtools/snowball-ts-sdk";
 
 interface MintedIglooNFTProps {
   nftLabel: string;

--- a/src/pages/Views/WalletView.tsx
+++ b/src/pages/Views/WalletView.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import NavBar from "@/components/NavBar";
 import ColumnButton from "@/components/ColumnButton";
 import Card from "@/components/Card";
-import { Chain, alchemyAPIKey, getAlchemyNetwork } from "@/helpers/chains";
+import { alchemyAPIKey, getAlchemyNetwork, getIglooNFTAddress } from "@/helpers/chains";
 import {
   AuthViews,
   disconnect,
@@ -24,6 +24,7 @@ import { Address, encodeFunctionData } from "viem";
 import { IglooNFTABI } from "@/helpers/abis/IglooNFTABI";
 import { Alchemy, NftOrdering, OwnedNftsResponse } from "alchemy-sdk";
 import track from "@/helpers/analytics";
+import { Chain } from "@snowballtools/snowball-ts-sdk";
 
 export interface WalletViewProps {}
 
@@ -38,7 +39,7 @@ const WalletView = ({}: WalletViewProps) => {
     try {
       const address = await snowball.getAddress();
       const result = await snowball.sendUserOperation(
-        currentAppChain.iglooNFTAddress,
+        getIglooNFTAddress(currentAppChain),
         encodeFunctionData({
           abi: IglooNFTABI.abi,
           functionName: "safeMint",
@@ -56,7 +57,7 @@ const WalletView = ({}: WalletViewProps) => {
       let mintedNFTs: OwnedNftsResponse = await alchemy.nft.getNftsForOwner(
         address,
         {
-          contractAddresses: [currentAppChain.iglooNFTAddress as Address],
+          contractAddresses: [getIglooNFTAddress(currentAppChain)],
           orderBy: NftOrdering.TRANSFERTIME,
         }
       );
@@ -102,7 +103,7 @@ const WalletView = ({}: WalletViewProps) => {
           window.open(
             nftId
               ? `https://testnets.opensea.io/assets/${currentAppChain.name.toLowerCase()}/${
-                  currentAppChain.iglooNFTAddress
+                  getIglooNFTAddress(currentAppChain)
                 }/${nftId}`
               : `https://www.jiffyscan.xyz/userOpHash/${userOpHash}?network=${currentAppChain.name.toLowerCase()}`,
             "_blank"

--- a/src/pages/api/iglooNFTWebhook.ts
+++ b/src/pages/api/iglooNFTWebhook.ts
@@ -1,5 +1,4 @@
 import {
-  Chain,
   alchemyAPIKey,
   getChainWebhookID,
   getChainWebhookSigningKey,
@@ -7,6 +6,7 @@ import {
 import type { NextApiRequest, NextApiResponse } from "next";
 import * as crypto from "crypto";
 import { logMetadata, logErrorMsg, logInfo } from "@/helpers/bugsnag";
+import { Chain } from "@snowballtools/snowball-ts-sdk";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {

--- a/src/store/credentialsSlice.ts
+++ b/src/store/credentialsSlice.ts
@@ -1,6 +1,6 @@
 import { AuthMethod, SessionSigsMap } from "@lit-protocol/types";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { Chain, CHAINS } from "@/helpers/chains";
+import { CHAINS, Chain } from "@snowballtools/snowball-ts-sdk";
 import { Address } from "viem";
 import { DEFAULT_CHAIN } from '../helpers/chains';
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request involves importing the `Chain` interface from a different module in two different files: `ChainMenuItem.tsx` and `DropDownMenu.tsx`. The previous import statement for `Chain` has been replaced with a new import statement from the `@snowballtools/snowball-ts-sdk` module.
> 
> ## What changed
> - The import statements for the `Chain` module in `ChainMenuItem.tsx` and `DropDownMenu.tsx` have been changed from `@/helpers/chains` to `@snowballtools/snowball-ts-sdk`.
> - The `CHAINS` constant from `@/helpers/chains` is no longer being used.
> 
> ## How to test
> 1. Clone the repository.
> 2. Checkout the branch containing this pull request.
> 3. Run the application.
> 4. Verify that the dropdown menu and navigation bar are functioning correctly.
> 5. Test the functionality of the test view.
> 6. Verify that the `Chain` module is imported correctly from the `@snowballtools/snowball-ts-sdk` module.
> 
> ## Why make this change
> - The previous import statements were referencing the `Chain` module from the `@/helpers/chains` module, which is no longer needed.
> - The new import statements from the `@snowballtools/snowball-ts-sdk` module provide the necessary functionality for the dropdown menu, navigation bar, and test view.
> - This change improves the maintainability and readability of the code by using a more appropriate module for importing the `Chain` interface.
</details>