### PR TITLE
fix env NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID

### DIFF
--- a/src/helpers/webauthn.ts
+++ b/src/helpers/webauthn.ts
@@ -22,7 +22,7 @@ export const snowball = new Snowball(
       [AlchemySmartWalletProviderKey.ethereumSepolia]: process.env
         .NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY as string,
       [AlchemySmartWalletProviderKey.ethereumSepolia_gasPolicyId]: process.env
-        .NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY as string,
+        .NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID as string,
     },
   }
 );


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request corrects an environment variable reference in the `webauthn.ts` helper file. The `ethereumSepolia_gasPolicyId` key now correctly references the `NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID` environment variable instead of the `NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY`.
> 
> ## What changed
> In the `webauthn.ts` file, the value for the `ethereumSepolia_gasPolicyId` key in the `snowball` object was changed from `NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY` to `NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID`.
> 
> ```diff
> -        .NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY as string,
> +        .NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID as string,
> ```
> 
> ## How to test
> 1. Pull down the changes from this branch.
> 2. Ensure you have the `NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID` environment variable set in your environment.
> 3. Run the application and observe that the `ethereumSepolia_gasPolicyId` key correctly references the `NEXT_PUBLIC_ALCHEMY_SEPOLIA_GAS_POLICY_ID` environment variable.
> 
> ## Why make this change
> This change is necessary to ensure that the `ethereumSepolia_gasPolicyId` key correctly references the intended environment variable. Previously, it was incorrectly referencing the `NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY` variable, which could lead to unexpected behavior or errors.
</details>