### PR TITLE
default sepolia and disable goerli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 next-env.d.ts
 
 yarn.lock
+.env

--- a/src/helpers/chains.ts
+++ b/src/helpers/chains.ts
@@ -42,7 +42,7 @@ export const CHAINS = {
     rpcUrls: ["https://eth-goerli.g.alchemy.com/v2/"],
     blockExplorerUrls: ["https://goerli.etherscan.io"],
     type: "ERC1155",
-    enabled: true,
+    enabled: false,
     vmType: "EVM",
     testNetwork: true,
     factoryAddress: "0x3c752E964f94A6e45c9547e86C70D3d9b86D3b17" as Address,
@@ -173,7 +173,7 @@ export const CHAINS = {
   },
 } as { [key: string]: Chain };
 
-export const DEFAULT_CHAIN = CHAINS.goerli;
+export const DEFAULT_CHAIN = CHAINS.sepolia;
 
 export function alchemyAPIKey(chain: Chain): string {
   switch (chain) {

--- a/src/helpers/webauthn.ts
+++ b/src/helpers/webauthn.ts
@@ -8,17 +8,13 @@ import {
 
 export const snowball = new Snowball(
   "snowball-test",
-  CHAINS.goerli,
+  CHAINS.sepolia,
   {
     name: AuthProvider.lit,
   },
   {
     name: SmartWalletProvider.alchemy,
     apiKeys: {
-      [AlchemySmartWalletProviderKey.ethereumGoerli]: process.env
-        .NEXT_PUBLIC_ALCHEMY_GOERLI_API_KEY as string,
-      [AlchemySmartWalletProviderKey.ethereumGoerli_gasPolicyId]: process.env
-        .NEXT_PUBLIC_ALCHEMY_GOERLI_GAS_POLICY_ID as string,
       [AlchemySmartWalletProviderKey.ethereumSepolia]: process.env
         .NEXT_PUBLIC_ALCHEMY_SEPOLIA_API_KEY as string,
       [AlchemySmartWalletProviderKey.ethereumSepolia_gasPolicyId]: process.env

--- a/src/store/credentialsSlice.ts
+++ b/src/store/credentialsSlice.ts
@@ -2,6 +2,7 @@ import { AuthMethod, SessionSigsMap } from "@lit-protocol/types";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Chain, CHAINS } from "@/helpers/chains";
 import { Address } from "viem";
+import { DEFAULT_CHAIN } from '../helpers/chains';
 
 export const AuthViews = {
   INITIAL_VIEW: "initial_view",
@@ -44,7 +45,7 @@ export const initialState: CredentialState = {
   currentAuthMethod: undefined,
   sessionSigs: {},
   sessionExpiration: null,
-  currentAppChain: CHAINS.goerli,
+  currentAppChain: DEFAULT_CHAIN,
   appChains: CHAINS,
   errorMsg: null,
   userOpHash: null,


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request changes the default chain from `goerli` to `sepolia` in the application. It also adds `.env` to `.gitignore` to prevent accidental commit of environment variables.
> 
> ## What changed
> - The default chain in `chains.ts` and `webauthn.ts` has been changed from `goerli` to `sepolia`.
> - The `.env` file has been added to `.gitignore`.
> - The `currentAppChain` in `credentialsSlice.ts` has been changed to use `DEFAULT_CHAIN` from `chains.ts`.
> 
> ## How to test
> 1. Pull the changes from this branch.
> 2. Run the application.
> 3. Check if the default chain is now `sepolia`.
> 4. Make sure the `.env` file is not being tracked by git.
> 
> ## Why make this change
> The change in the default chain is necessary to align the application with the current blockchain network being used. Adding `.env` to `.gitignore` is a good practice to prevent sensitive data from being exposed.
</details>